### PR TITLE
Fix: WatchConnectivity Crash Issues on Unsupported or Unreachable Devices

### DIFF
--- a/lib/providers/login_provider.dart
+++ b/lib/providers/login_provider.dart
@@ -1,5 +1,4 @@
 import 'package:finance_track/screens/watch_screens/authorize.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:watch_connectivity/watch_connectivity.dart';
@@ -10,16 +9,17 @@ class LoginProvider with ChangeNotifier {
 
   bool get isLoggedIn => _isLoggedIn;
 
-  Future<void> login(String email, String password, WatchConnectivity _watchConnectivity) async
-  {
-
+  Future<void> login(
+    String email,
+    String password,
+    WatchConnectivity _watchConnectivity,
+  ) async {
     try {
       UserCredential userCredential = await FirebaseAuth.instance
           .signInWithEmailAndPassword(email: email, password: password);
       User? user = userCredential.user;
 
-      if (user != null)
-      {
+      if (user != null) {
         _isLoggedIn = true;
 
         final prefs = await SharedPreferences.getInstance();
@@ -35,82 +35,115 @@ class LoginProvider with ChangeNotifier {
 
         notifyListeners();
       }
-    }
-    catch (e)
-    {
+    } catch (e) {
       print("Login failed: $e");
       throw Exception('Login Error: $e');
     }
   }
 
-  void isAccessed(final uid, WatchConnectivity _watchConnectivity) async {
-    if (await _watchConnectivity.isReachable)
-    {
-      await _watchConnectivity.sendMessage({
-        "Accessed": true,
-        "uid": uid,
-      });
-      print("Message is sent to Mobile OS");
-    }
-    else
-    {
-      print("Mobile OS device is not reachable");
+  Future<void> isAccessed(
+    String uid,
+    WatchConnectivity _watchConnectivity,
+  ) async {
+    try {
+      final isSupported = await _watchConnectivity.isSupported;
+      final isReachable = await _watchConnectivity.isReachable;
+
+      if (!isSupported) {
+        print("WatchConnectivity not supported on this device.");
+        return;
+      }
+
+      if (isReachable) {
+        await _watchConnectivity.sendMessage({"Accessed": true, "uid": uid});
+        print("Access message sent to Wear OS.");
+      } else {
+        print("Wear OS device is not reachable.");
+      }
+    } catch (e, stackTrace) {
+      print("Error in isAccessed: $e");
+      print("StackTrace: $stackTrace");
     }
   }
 
   void isLoggedIN(WatchConnectivity _watchConnectivity) async {
-    if (await _watchConnectivity.isReachable)
-    {
-      await _watchConnectivity.sendMessage({
-        "isWearLoggedIn": true,
-      });
-      print("Message is sent to Wear OS");
-    }
-    else
-    {
-      print("Wear OS device is not reachable");
-    }
-  }
+    try {
+      final isSupported = await _watchConnectivity.isSupported;
+      final isReachable = await _watchConnectivity.isReachable;
 
-
-  void isLogout(WatchConnectivity _watchConnectivity) async {
-    if (await _watchConnectivity.isReachable)
-    {
-      await _watchConnectivity.sendMessage({
-        "Logout": true,
-      });
-      print("Message is sent to Wear OS");
-    }
-    else
-    {
-      print("Wear OS device is not reachable");
-    }
-  }
-
-   void wearOsLogout(WatchConnectivity _watchConnectivity, BuildContext context) async {
-    _watchConnectivity.messageStream.listen((message) {
-      if (message["Logout"] == true)
-      {
-        Navigator.push(context, MaterialPageRoute(builder: (context) =>Authorize()));
+      if (!isSupported) {
+        print("WatchConnectivity not supported on this device.");
+        return;
       }
-      else
-      {
-       print("Can't logout");
+
+      if (isReachable) {
+        await _watchConnectivity.sendMessage({"isWearLoggedIn": true});
+        print("Message sent to Wear OS.");
+      } else {
+        print("Wear OS device is not reachable.");
+      }
+    } catch (e, stackTrace) {
+      print("Error in isLoggedIN: $e");
+      print("StackTrace: $stackTrace");
+    }
+  }
+
+  Future<void> logout(WatchConnectivity _watchConnectivity) async {
+    try {
+      await FirebaseAuth.instance.signOut();
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.clear();
+
+      await safeLogoutWatchMessage(_watchConnectivity);
+
+      _isLoggedIn = false;
+      notifyListeners();
+      print("Logout completed");
+    } catch (e, stackTrace) {
+      print("Error during logout: $e");
+      print("StackTrace: $stackTrace");
+    }
+  }
+
+  Future<void> safeLogoutWatchMessage(
+    WatchConnectivity _watchConnectivity,
+  ) async {
+    try {
+      final isSupported = await _watchConnectivity.isSupported;
+      final isReachable = await _watchConnectivity.isReachable;
+
+      if (!isSupported) {
+        print("WatchConnectivity not supported on this device.");
+        return;
+      }
+
+      if (isReachable) {
+        await _watchConnectivity.sendMessage({"Logout": true});
+        print("Logout message sent to Wear OS.");
+      } else {
+        print("Wear OS device is not reachable.");
+      }
+    } catch (e, stackTrace) {
+      print("Error in isLogout: $e");
+      print("StackTrace: $stackTrace");
+    }
+  }
+
+  void wearOsLogout(
+    WatchConnectivity _watchConnectivity,
+    BuildContext context,
+  ) async {
+    _watchConnectivity.messageStream.listen((message) {
+      if (message["Logout"] == true) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => Authorize()),
+        );
+      } else {
+        print("Can't logout");
       }
       notifyListeners();
     });
-  }
-
-
-  Future<void> logout(WatchConnectivity _watchConnectivity) async {
-    await FirebaseAuth.instance.signOut();
-
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
-
-    isLogout(_watchConnectivity);
-
-    _isLoggedIn = false;
-    notifyListeners();
   }
 }


### PR DESCRIPTION
### Summary
This merge request addresses multiple crash issues related to WatchConnectivity when running on devices that do not support Wear OS or have unreachable watch connections.

### Changes Made
- Wrapped `isLoggedIN`, `isAccessed`, and `logout` methods with:
  - `isSupported` check
  - `isReachable` check
  - `try-catch` blocks for error safety
- Extracted safe message sending into `safeLogoutWatchMessage`
- Improved logging for better debugging
- Prevented app crashes when WatchConnectivity APIs are unavailable

### Testing
- Verified login/logout flow on Android device without Wear OS
- Ensured safe fallback when watch is disconnected or unsupported

### Related Issue
Closes #watch-api-crash

